### PR TITLE
Chain adapter refactor

### DIFF
--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
@@ -2,7 +2,6 @@ package nl.tudelft.cs4160.trustchain_android.chainExplorer;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,10 +18,8 @@ import nl.tudelft.cs4160.trustchain_android.block.TrustChainBlock;
 import nl.tudelft.cs4160.trustchain_android.message.MessageProto;
 
 import static nl.tudelft.cs4160.trustchain_android.Peer.bytesToHex;
-import static nl.tudelft.cs4160.trustchain_android.block.TrustChainBlock.pubKeyToString;
 
 public class ChainExplorerAdapter extends BaseAdapter{
-    static final String TAG = "ChainExplorerAdapter";
 
     Context context;
     List<MessageProto.TrustChainBlock> blocksList;

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
@@ -39,7 +39,7 @@ public class ChainExplorerAdapter extends BaseAdapter {
     }
 
     @Override
-    public Object getItem(int position) {
+    public MessageProto.TrustChainBlock getItem(int position) {
         return blocksList.get(position);
     }
 
@@ -58,7 +58,7 @@ public class ChainExplorerAdapter extends BaseAdapter {
      */
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
-        MessageProto.TrustChainBlock block = (MessageProto.TrustChainBlock) getItem(position);
+        MessageProto.TrustChainBlock block = getItem(position);
         if (convertView == null) {
             convertView = LayoutInflater.from(context).inflate(R.layout.item_trustchainblock,
                     parent, false);

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
@@ -67,37 +67,13 @@ public class ChainExplorerAdapter extends BaseAdapter {
         // Check if we already know the peer, otherwise add it to the peerList
         ByteString pubKeyByteStr = block.getPublicKey();
         ByteString linkPubKeyByteStr = block.getLinkPublicKey();
-        String peerAlias;
-        String linkPeerAlias;
 
-        if (peerList.containsKey(pubKeyByteStr)) {
-            peerAlias = peerList.get(pubKeyByteStr);
-        } else {
-            peerAlias = "peer" + (peerList.size() - 1);
-            peerList.put(pubKeyByteStr, peerAlias);
-        }
-
-        if (peerList.containsKey(linkPubKeyByteStr)) {
-            linkPeerAlias = peerList.get(linkPubKeyByteStr);
-        } else {
-            linkPeerAlias = "peer" + (peerList.size() - 1);
-            peerList.put(linkPubKeyByteStr, linkPeerAlias);
-        }
+        String peerAlias = findInPeersOrAdd(pubKeyByteStr);
+        String linkPeerAlias = findInPeersOrAdd(linkPubKeyByteStr);
 
         // Check if the sequence numbers are 0, which would mean that they are unknown
-        String seqNumStr;
-        String linkSeqNumStr;
-        if (block.getSequenceNumber() == 0) {
-            seqNumStr = "unknown";
-        } else {
-            seqNumStr = String.valueOf(block.getSequenceNumber());
-        }
-
-        if (block.getLinkSequenceNumber() == 0) {
-            linkSeqNumStr = "unknown";
-        } else {
-            linkSeqNumStr = String.valueOf(block.getLinkSequenceNumber());
-        }
+        String seqNumStr = displayStringForSequenceNumber(block.getSequenceNumber());
+        String linkSeqNumStr = displayStringForSequenceNumber(block.getLinkSequenceNumber());
 
         // collapsed view
         TextView peer = (TextView) convertView.findViewById(R.id.peer);
@@ -133,4 +109,26 @@ public class ChainExplorerAdapter extends BaseAdapter {
         }
         return convertView;
     }
+
+    // Check if we already know the peer, otherwise add it to the peerList
+    String findInPeersOrAdd(ByteString keyByteString) {
+        if (peerList.containsKey(keyByteString)) {
+            return peerList.get(keyByteString);
+        } else {
+            String peerAlias = "peer" + (peerList.size() - 1);
+            peerList.put(keyByteString, peerAlias);
+            return peerAlias;
+        }
+    }
+
+    // Check if the sequence numbers are 0, which would mean that they are unknown
+    static String displayStringForSequenceNumber(int sequenceNumber) {
+        if (sequenceNumber == 0) {
+            return "unknown";
+        } else {
+            return String.valueOf(sequenceNumber);
+        }
+
+    }
+
 }

--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapter.java
@@ -19,18 +19,18 @@ import nl.tudelft.cs4160.trustchain_android.message.MessageProto;
 
 import static nl.tudelft.cs4160.trustchain_android.Peer.bytesToHex;
 
-public class ChainExplorerAdapter extends BaseAdapter{
+public class ChainExplorerAdapter extends BaseAdapter {
 
     Context context;
     List<MessageProto.TrustChainBlock> blocksList;
-    HashMap<ByteString,String> peerList = new HashMap<>();
+    HashMap<ByteString, String> peerList = new HashMap<>();
 
     public ChainExplorerAdapter(Context context, List<MessageProto.TrustChainBlock> blocksList, byte[] myPubKey) {
         this.context = context;
         this.blocksList = blocksList;
         // put my public key in the peerList
-        peerList.put(ByteString.copyFrom(myPubKey),"me");
-        peerList.put(TrustChainBlock.EMPTY_PK,"unknown");
+        peerList.put(ByteString.copyFrom(myPubKey), "me");
+        peerList.put(TrustChainBlock.EMPTY_PK, "unknown");
     }
 
     @Override
@@ -50,6 +50,7 @@ public class ChainExplorerAdapter extends BaseAdapter{
 
     /**
      * Puts the data from a TrustChainBlock object into the item textview.
+     *
      * @param position
      * @param convertView
      * @param parent
@@ -69,30 +70,30 @@ public class ChainExplorerAdapter extends BaseAdapter{
         String peerAlias;
         String linkPeerAlias;
 
-        if(peerList.containsKey(pubKeyByteStr)) {
+        if (peerList.containsKey(pubKeyByteStr)) {
             peerAlias = peerList.get(pubKeyByteStr);
         } else {
-            peerAlias = "peer" + (peerList.size()-1);
-            peerList.put(pubKeyByteStr,peerAlias);
+            peerAlias = "peer" + (peerList.size() - 1);
+            peerList.put(pubKeyByteStr, peerAlias);
         }
 
-        if(peerList.containsKey(linkPubKeyByteStr)) {
+        if (peerList.containsKey(linkPubKeyByteStr)) {
             linkPeerAlias = peerList.get(linkPubKeyByteStr);
         } else {
-            linkPeerAlias = "peer" + (peerList.size()-1);
-            peerList.put(linkPubKeyByteStr,linkPeerAlias);
+            linkPeerAlias = "peer" + (peerList.size() - 1);
+            peerList.put(linkPubKeyByteStr, linkPeerAlias);
         }
 
         // Check if the sequence numbers are 0, which would mean that they are unknown
         String seqNumStr;
         String linkSeqNumStr;
-        if(block.getSequenceNumber() == 0) {
+        if (block.getSequenceNumber() == 0) {
             seqNumStr = "unknown";
         } else {
             seqNumStr = String.valueOf(block.getSequenceNumber());
         }
 
-        if(block.getLinkSequenceNumber() == 0) {
+        if (block.getLinkSequenceNumber() == 0) {
             linkSeqNumStr = "unknown";
         } else {
             linkSeqNumStr = String.valueOf(block.getLinkSequenceNumber());
@@ -125,7 +126,7 @@ public class ChainExplorerAdapter extends BaseAdapter{
         signature.setText(bytesToHex(block.getSignature().toByteArray()));
         expTransaction.setText(block.getTransaction().toStringUtf8());
 
-        if(peerAlias.equals("me") || linkPeerAlias.equals("me")) {
+        if (peerAlias.equals("me") || linkPeerAlias.equals("me")) {
             convertView.findViewById(R.id.own_chain_indicator).setBackgroundColor(Color.GREEN);
         } else {
             convertView.findViewById(R.id.own_chain_indicator).setBackgroundColor(Color.TRANSPARENT);

--- a/app/src/test/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapterTest.java
+++ b/app/src/test/java/nl/tudelft/cs4160/trustchain_android/chainExplorer/ChainExplorerAdapterTest.java
@@ -1,0 +1,51 @@
+package nl.tudelft.cs4160.trustchain_android.chainExplorer;
+
+
+import com.google.protobuf.ByteString;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ChainExplorerAdapterTest {
+    private static final ByteString PEER_2_PEER = ByteString.copyFromUtf8("peer2peer");
+    private ChainExplorerAdapter adapter = new ChainExplorerAdapter(null, null, new byte[0]);
+
+    @Test
+    public void find_peer_in_list() {
+        adapter.peerList = singlePeer();
+        String peerString = adapter.findInPeersOrAdd(PEER_2_PEER);
+
+        assertEquals(peerString, "me");
+    }
+
+    @Test
+    public void add_peer_if_not_in_list() {
+        adapter.peerList = singlePeer();
+        ByteString newPeer = ByteString.copyFromUtf8("new peer");
+        String peerString = adapter.findInPeersOrAdd(newPeer);
+
+        assertEquals(peerString, "peer0");
+        assertTrue(adapter.peerList.containsKey(newPeer));
+    }
+
+    private static HashMap<ByteString, String> singlePeer() {
+        HashMap<ByteString, String> peers = new HashMap<>();
+        peers.put(PEER_2_PEER, "me");
+
+        return peers;
+    }
+
+    @Test
+    public void string_for_known_sequence_number() {
+        assertEquals("42", ChainExplorerAdapter.displayStringForSequenceNumber(42));
+    }
+
+    @Test
+    public void string_for_unknown_sequence_number() {
+        assertEquals("unknown", ChainExplorerAdapter.displayStringForSequenceNumber(0));
+    }
+}


### PR DESCRIPTION
Removes redundant casts, dead imports, and fields.

Extracts some duplicate logic and tests it.
Please note that if #49 is merged, the newer API would make all casts for finding views by id redundant.
