### PR TITLE
Make SocketServerThread implement runnable to avoid duplicate thread allocation

### DIFF
--- a/app/src/main/java/nl/tudelft/cs4160/trustchain_android/connection/network/Server.java
+++ b/app/src/main/java/nl/tudelft/cs4160/trustchain_android/connection/network/Server.java
@@ -39,7 +39,7 @@ class Server {
 
     }
 
-    private class SocketServerThread extends Thread {
+    private class SocketServerThread implements Runnable {
         static final int SocketServerPORT = 8080;
         int count = 0;
 


### PR DESCRIPTION
Please notice that here: https://github.com/LiamClark/CS4160-trustchain-android/blob/cd2ea6a54d4b122ef12611f462ea8c5fd6312bcf/app/src/main/java/nl/tudelft/cs4160/trustchain_android/connection/network/Server.java#L37

The SocketServerThread is actually used as a runnable and wrapped in another thread, which then executes this threads version of run. This means we allocate resources for two threads but only ever use the outer one.

Further more the SocketServerReplyThread is currently completely dead code.
Would this be used in the future or could we remove it?
same goes for the count field in SocketServerThread